### PR TITLE
test: fix webserver command

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -53,7 +53,7 @@ export default defineConfig({
 
   /* Run local dev server before starting the tests */
   webServer: {
-    command: 'npm start',
+    command: process.env.CI ? 'node .next/standalone/server.js' : 'npm start',
     reuseExistingServer: !process.env.CI,
     stderr: 'pipe',
     stdout: 'ignore',


### PR DESCRIPTION
- Change webServer.command to `process.env.CI ? 'node .next/standalone/server.js' : 'npm start'`